### PR TITLE
Fix channel and user id assignment

### DIFF
--- a/src/SlackRTMDriver.php
+++ b/src/SlackRTMDriver.php
@@ -146,8 +146,16 @@ class SlackRTMDriver implements DriverInterface
     public function getMessages()
     {
         $messageText = $this->event->get('text');
+
         $user_id = $this->event->get('user');
+        if (is_array($user_id)) {
+            $user_id = $user_id['id'];
+        }
+
         $channel_id = $this->event->get('channel');
+        if (is_array($channel_id)) {
+            $channel_id = $channel_id['id'];
+        }
 
         if ($this->event->get('subtype') === 'file_share') {
             $file = Collection::make($this->event->get('file'));

--- a/tests/SlackRTMDriverTest.php
+++ b/tests/SlackRTMDriverTest.php
@@ -88,6 +88,13 @@ class SlackRTMDriverTest extends PHPUnit_Framework_TestCase
         $driver = $this->getDriver([
             'user' => 'U0X12345',
         ]);
+
+        $this->assertSame('U0X12345', $driver->getMessages()[0]->getSender());
+
+        $driver = $this->getDriver([
+            'user' => ['id' => 'U0X12345'],
+        ]);
+
         $this->assertSame('U0X12345', $driver->getMessages()[0]->getSender());
     }
 
@@ -98,6 +105,14 @@ class SlackRTMDriverTest extends PHPUnit_Framework_TestCase
             'user' => 'U0X12345',
             'channel' => 'general',
         ]);
+
+        $this->assertSame('general', $driver->getMessages()[0]->getRecipient());
+
+        $driver = $this->getDriver([
+            'user' =>  'U0X12345',
+            'channel' => ['id' => 'general'],
+        ]);
+
         $this->assertSame('general', $driver->getMessages()[0]->getRecipient());
     }
 


### PR DESCRIPTION
On some event the `user` and `channel` data from the payload are not their id, but an array with all the object data.

Compare https://api.slack.com/events/message with https://api.slack.com/events/user_change or https://api.slack.com/events/channel_joined