### PR TITLE
Feature - add bot to bot communication to slack drivers

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -359,9 +359,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
     }
 
     /**
-     *
      * Get bot userID.
-     *
      */
     private function getBotUserId()
     {

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -56,7 +56,9 @@ class SlackDriver extends HttpDriver implements VerifiesService
         } else {
             $this->payload = new ParameterBag((array) json_decode($request->getContent(), true));
             $this->event = Collection::make($this->payload->get('event'));
-            $this->getBotUserId();
+            if (!empty($this->config['token']) && empty($this->botID)) {
+                $this->getBotUserId();
+            }
         }
     }
 
@@ -350,7 +352,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
     {
         $message = $this->getMessages()[0];
         $botUserIdRequest = $this->sendRequest('auth.test', [], $message);
-        $botUserIdPayload = new ParameterBag((array) json_decode($botUserIdRequest->getContent(), true));
+        $botUserIdPayload = new ParameterBag((array)json_decode($botUserIdRequest->getContent(), true));
 
         if ($botUserIdPayload->get('user_id')) {
             $this->botUserID = $botUserIdPayload->get('user_id');

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -382,8 +382,8 @@ class SlackDriver extends HttpDriver implements VerifiesService
         $botUserRequest = $this->sendRequest('users.info', ['user' => $this->botUserID], $message);
         $botUserPayload = (array) json_decode($botUserRequest->getContent(), true);
 
-        if ($botUserPayload['user']['name']) {
-            $this->botUserName = ucfirst($botUserPayload['user']['name']);
+        if ($botUserPayload['user']['is_bot']) {
+            $this->botID = $botUserPayload['user']['profile']['bot_id'];
         }
     }
 }

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -27,6 +27,10 @@ class SlackDriver extends HttpDriver implements VerifiesService
 
     protected $resultType = self::RESULT_JSON;
 
+    protected $botID;
+
+    protected $botUserID;
+
     /**
      * @param Request $request
      */

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -67,7 +67,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     public function matchesRequest()
     {
-        return !is_null($this->event->get('user')) || !is_null($this->event->get('team_domain')) || !is_null($this->event->get('bot_id'));
+        return ! is_null($this->event->get('user')) || ! is_null($this->event->get('team_domain')) || ! is_null($this->event->get('bot_id'));
     }
 
     /**
@@ -360,14 +360,14 @@ class SlackDriver extends HttpDriver implements VerifiesService
 
     /**
      *
-     * Get bot userID
+     * Get bot userID.
      *
      */
     private function getBotUserId()
     {
         $message = $this->getMessages()[0];
         $botUserIdRequest = $this->sendRequest('auth.test', [], $message);
-        $botUserIdPayload = new ParameterBag((array)json_decode($botUserIdRequest->getContent(), true));
+        $botUserIdPayload = new ParameterBag((array) json_decode($botUserIdRequest->getContent(), true));
 
         if ($botUserIdPayload->get('user_id')) {
             $this->botUserID = $botUserIdPayload->get('user_id');
@@ -376,13 +376,13 @@ class SlackDriver extends HttpDriver implements VerifiesService
     }
 
     /**
-     * Get bot ID
+     * Get bot ID.
      */
     private function getBotId()
     {
         $message = $this->getMessages()[0];
         $botUserRequest = $this->sendRequest('users.info', ['user' => $this->botUserID], $message);
-        $botUserPayload = (array)json_decode($botUserRequest->getContent(), true);
+        $botUserPayload = (array) json_decode($botUserRequest->getContent(), true);
 
         if ($botUserPayload['user']['name']) {
             $this->botUserName = ucfirst($botUserPayload['user']['name']);

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -67,7 +67,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     public function matchesRequest()
     {
-        return ! is_null($this->event->get('user')) || ! is_null($this->event->get('team_domain'));
+        return !is_null($this->event->get('user')) || !is_null($this->event->get('team_domain')) || !is_null($this->event->get('bot_id'));
     }
 
     /**
@@ -131,7 +131,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     protected function isBot()
     {
-        return $this->event->has('bot_id');
+        return $this->event->has('bot_id') && $this->event->get('bot_id') == $this->botID;
     }
 
     /**

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -56,7 +56,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
         } else {
             $this->payload = new ParameterBag((array) json_decode($request->getContent(), true));
             $this->event = Collection::make($this->payload->get('event'));
-            if (!empty($this->config['token']) && empty($this->botID)) {
+            if (! empty($this->config['token']) && empty($this->botID)) {
                 $this->getBotUserId();
             }
         }
@@ -352,7 +352,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
     {
         $message = $this->getMessages()[0];
         $botUserIdRequest = $this->sendRequest('auth.test', [], $message);
-        $botUserIdPayload = new ParameterBag((array)json_decode($botUserIdRequest->getContent(), true));
+        $botUserIdPayload = new ParameterBag((array) json_decode($botUserIdRequest->getContent(), true));
 
         if ($botUserIdPayload->get('user_id')) {
             $this->botUserID = $botUserIdPayload->get('user_id');

--- a/src/SlackRTMDriver.php
+++ b/src/SlackRTMDriver.php
@@ -34,6 +34,9 @@ class SlackRTMDriver implements DriverInterface
     /** @var string */
     protected $bot_id;
 
+    /** @var string */
+    protected $botUserID;
+
     const DRIVER_NAME = 'SlackRTM';
 
     protected $file;
@@ -65,7 +68,10 @@ class SlackRTMDriver implements DriverInterface
     public function connected()
     {
         $this->client->getAuthedUser()->then(function ($user) {
-            $this->bot_id = $user->getId();
+            $this->botUserID = $user->getId();
+            if (isset($user->data['is_bot']) && $user->data['is_bot']) {
+                $this->bot_id = $user->data['profile']['bot_id'];
+            }
         });
     }
 

--- a/src/SlackRTMDriver.php
+++ b/src/SlackRTMDriver.php
@@ -198,7 +198,7 @@ class SlackRTMDriver implements DriverInterface
      */
     protected function isBot()
     {
-        return $this->event->has('bot_id') && $this->event->get('bot_id') !== $this->bot_id;
+        return $this->event->has('bot_id') && $this->event->get('bot_id') == $this->bot_id;
     }
 
     /**

--- a/tests/SlackDriverTest.php
+++ b/tests/SlackDriverTest.php
@@ -199,7 +199,6 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
 
         $response = new Response('{"ok":true,"user":{"id": "U0X12345","name": "botman","deleted": false,"color": "9f69e7","profile": {"bot_id":"foo", "avatar_hash": "ge3b51ca72de","status_emoji": ":mountain_railway:","status_text": "riding a train","first_name": "Bot","last_name": "Man","real_name": "Bot Man","email": "botman@foo.bar","skype": "my-skype-name","phone": "+1 (123) 456 7890","image_24": "http:\/\/via.placeholder.com\/24","image_32": "http:\/\/via.placeholder.com\/32","image_48": "http:\/\/via.placeholder.com\/48","image_72": "http:\/\/via.placeholder.com\/72","image_192": "http:\/\/via.placeholder.com\/192","image_512": "http:\/\/via.placeholder.com\/512"},"is_admin": true, "is_owner": true,"is_primary_owner": true,"is_restricted": false,"is_ultra_restricted": false,"updated": 1490054400,"has_2fa": false,"two_factor_type": "sms","is_bot": true}}');
 
-
         $html->shouldReceive('post')
             ->with('https://slack.com/api/users.info', [], [
                 'token' => 'Foo',
@@ -408,7 +407,6 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
 
         $this->mockAuthTestEndpoint($html);
         $this->mockUserInfoEndpoint($html);
-
 
         $html->shouldReceive('post')
             ->once()

--- a/tests/SlackDriverTest.php
+++ b/tests/SlackDriverTest.php
@@ -767,7 +767,7 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
     }
 
     /**
-     * Mocks the auth.test endpoint request
+     * Mocks the auth.test endpoint request.
      *
      * @param $htmlInterface
      */
@@ -778,13 +778,13 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
         $htmlInterface->shouldReceive('post')
             ->once()
             ->with('https://slack.com/api/auth.test', [], [
-                'token' => "Foo"
+                'token' => 'Foo'
             ])
             ->andReturn($response);
     }
 
     /**
-     * Mocks the users.info endpoint request
+     * Mocks the users.info endpoint request.
      *
      * @param $htmlInterface
      */

--- a/tests/SlackDriverTest.php
+++ b/tests/SlackDriverTest.php
@@ -778,7 +778,7 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
         $htmlInterface->shouldReceive('post')
             ->once()
             ->with('https://slack.com/api/auth.test', [], [
-                'token' => 'Foo'
+                'token' => 'Foo',
             ])
             ->andReturn($response);
     }

--- a/tests/SlackDriverTest.php
+++ b/tests/SlackDriverTest.php
@@ -32,12 +32,12 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
         }
 
         $slackConfig = ['token' => 'Foo'];
-        $message = new IncomingMessage('', 'U0X12345', 'general');
+        $response = new Response('{"ok": true,"url": "https:\/\/myteam.slack.com\/","team": "My Team","user": "cal","team_id": "T12345","user_id": "U0X12345"}');
 
         $htmlInterface->shouldReceive('post')
             ->once()
             ->with('https://slack.com/api/auth.test', [], $slackConfig)
-            ->andReturn(json_encode($responseData));
+            ->andReturn($response);
 
         return new SlackDriver($request, ['slack' => $slackConfig], $htmlInterface);
     }

--- a/tests/SlackDriverTest.php
+++ b/tests/SlackDriverTest.php
@@ -31,7 +31,15 @@ class SlackDriverTest extends PHPUnit_Framework_TestCase
             $htmlInterface = m::mock(Curl::class);
         }
 
-        return new SlackDriver($request, [], $htmlInterface);
+        $slackConfig = ['token' => 'Foo'];
+        $message = new IncomingMessage('', 'U0X12345', 'general');
+
+        $htmlInterface->shouldReceive('post')
+            ->once()
+            ->with('https://slack.com/api/auth.test', [], $slackConfig)
+            ->andReturn(json_encode($responseData));
+
+        return new SlackDriver($request, ['slack' => $slackConfig], $htmlInterface);
     }
 
     /** @test */

--- a/tests/SlackRTMDriverTest.php
+++ b/tests/SlackRTMDriverTest.php
@@ -76,7 +76,7 @@ class SlackRTMDriverTest extends PHPUnit_Framework_TestCase
 
         $driver = $this->getDriver([
             'user' => 'U0X12345',
-            'bot_id' => 'foo',
+            'bot_id' => null,
             'text' => 'Hi Julia',
         ]);
         $messages = $driver->getMessages();


### PR DESCRIPTION
This PR add's the ability for a Botman bot  using the slack driver to receive messages from other bots within a slack team.

Still need to get the testing working.