### PR TITLE
Fix say method

### DIFF
--- a/src/SlackRTMDriver.php
+++ b/src/SlackRTMDriver.php
@@ -204,7 +204,7 @@ class SlackRTMDriver implements DriverInterface
     public function buildServicePayload($message, $matchingMessage, $additionalParameters = [])
     {
         $parameters = array_merge_recursive([
-            'channel' => $matchingMessage->getRecipient(),
+            'channel' => $matchingMessage->getRecipient() ?: $matchingMessage->getSender(),
             'as_user' => true,
         ], $additionalParameters);
 


### PR DESCRIPTION
Using `$botMan->say` does not work in combination with SlackRtmDriver due to the channel attribute being an empty string.