### PR TITLE
Replace keys instead of combining when merging multi-dimensional arrays

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -312,7 +312,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     protected function replyWithToken($message, $matchingMessage, $additionalParameters = [])
     {
-        $parameters = array_merge_recursive([
+        $parameters = array_replace_recursive([
             'as_user' => true,
             'token' => $this->payload->get('token'),
             'channel' => $matchingMessage->getRecipient() === '' ? $matchingMessage->getSender() : $matchingMessage->getRecipient(),

--- a/src/SlackRTMDriver.php
+++ b/src/SlackRTMDriver.php
@@ -214,7 +214,7 @@ class SlackRTMDriver implements DriverInterface
      */
     public function buildServicePayload($message, $matchingMessage, $additionalParameters = [])
     {
-        $parameters = array_merge_recursive([
+        $parameters = array_replace_recursive([
             'channel' => $matchingMessage->getRecipient() ?: $matchingMessage->getSender(),
             'as_user' => true,
         ], $additionalParameters);


### PR DESCRIPTION
This fixes https://github.com/botman/botman/issues/627 for the Slack drivers.