### PR TITLE
Remove composer suggestion

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,6 @@
         "mockery/mockery": "dev-master",
         "ext-curl": "*"
     },
-    "suggest": {
-        "mpociot/slack-client": "Use the Slack RTM API with BotMan"
-    },
     "autoload": {
         "psr-4": {
             "BotMan\\Drivers\\Slack\\": "src/"


### PR DESCRIPTION
Since `mpociot/slack-client` is required, there is no need for suggesting it.