### PR TITLE
make attachments work with token

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -363,7 +363,12 @@ class SlackDriver extends HttpDriver implements VerifiesService
             $attachment = $message->getAttachment();
             if (! is_null($attachment)) {
                 if ($attachment instanceof Image) {
-                    $parameters['attachments'] = json_encode(['image_url' => $attachment->getUrl()]);
+                    $parameters['attachments'] = json_encode([
+                        [
+                            'title' => $attachment->getTitle() ? $attachment->getTitle() : $attachment->getUrl(),
+                            'image_url' => $attachment->getUrl(),
+                        ],
+                    ]);
                 }
             }
         } else {


### PR DESCRIPTION
This PR uses the solution for the RTM Version to use the URL as attachment title if no title is set. Slack made the title mandatory to display the image attachment.