### PR TITLE
Fix: token provided by slack is always overriten by config one even w…

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -343,7 +343,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
     {
         $parameters = array_replace_recursive([
             'as_user' => true,
-            'token' => $this->payload->get('token'),
+            'token' => $this->payload->get('token', $this->config->get('token')),
             'channel' => $matchingMessage->getRecipient() === '' ? $matchingMessage->getSender() : $matchingMessage->getRecipient(),
         ], $additionalParameters);
 
@@ -369,8 +369,6 @@ class SlackDriver extends HttpDriver implements VerifiesService
         } else {
             $parameters['text'] = $message;
         }
-
-        $parameters['token'] = $this->config->get('token');
 
         return $parameters;
     }


### PR DESCRIPTION
The token parameter is always set at like 373 making line 346 without effect. The new implementation ensures that an existing token in the payload is used with failover to the configuration one