### PR TITLE
fixed json_decode exception if other drivers as payload array in request

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -53,7 +53,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
          * If the request has a POST parameter called 'payload'
          * we're dealing with an interactive button response.
          */
-        if (! is_null($request->get('payload'))) {
+        if (! is_null($request->get('payload')) && !is_array($request->get('payload'))) {
             $payloadData = json_decode($request->get('payload'), true);
 
             $this->payload = Collection::make($payloadData);


### PR DESCRIPTION
Throwing an exception in case of another driver as payload request array

```
{
    "uuid": "3e1a67ae-68a6-4f96-a56c-da30a69161f8",
    "sender": "792e0340-b1fc-478d-81e7-4a309eb6e168",
    "recipient": "919019955622",
    "messenger": "WB",
    "messenger_id": "gBEGkZAZlVYiAgl4NilSohFxunQ",
    "payload": {
        "type": "text",
        "text": "To connect the location, type \"connect <kiosk_code>\"\n<br/>To connect the location, type \"remove <kiosk_code>\"\n<br/>To unsubscribe, type \"stop\"\n<br/>To subscribe, type \"start\""
    },
    "outgoing": true,
    "statuscode": 200,
    "result": "{\"messages\":[{\"id\":\"gBEGkZAZlVYiAgl4NilSohFxunQ\"}],\"meta\":{\"api_status\":\"stable\",\"version\":\"2.25.5\"}}",
    "processed": 1581956246,
    "sent": 1581956246,
    "received": null,
    "read": null,
    "created": 1581956246
}

```

add condition to check it's not an array. 