### PR TITLE
Update deprecated Response constructors

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -236,7 +236,15 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     public function buildServicePayload($message, $matchingMessage, $additionalParameters = [])
     {
-        if (! Collection::make($matchingMessage->getPayload())->has('team_domain')) {
+        $matchingMessagePayload = $matchingMessage->getPayload();
+
+        // If the matching message is in a thread, reply there
+        $thread_ts = $matchingMessagePayload->get('thread_ts');
+        if (! empty($thread_ts)) {
+            $additionalParameters['thread_ts'] = $thread_ts;
+        }
+
+        if (! Collection::make($matchingMessagePayload)->has('team_domain')) {
             $this->resultType = self::RESULT_TOKEN;
             $payload = $this->replyWithToken($message, $matchingMessage, $additionalParameters);
         } else {
@@ -272,9 +280,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage, BotMan $bot)
     {
-        $additionalParameters['thread_ts'] = ! empty($matchingMessage->getPayload()->get('thread_ts'))
-            ? $matchingMessage->getPayload()->get('thread_ts')
-            : $matchingMessage->getPayload()->get('ts');
+        $additionalParameters['thread_ts'] = $matchingMessage->getPayload()->get('ts');
 
         $payload = $this->buildServicePayload($message, $matchingMessage, $additionalParameters);
 

--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -259,11 +259,13 @@ class SlackDriver extends HttpDriver implements VerifiesService
             return $this->http->post('https://slack.com/api/dialog.open', [], $payload);
         }
 
-        return JsonResponse::create($payload)->send();
+        $response = new JsonResponse($payload);
+
+        return $response->send();
     }
 
     /**
-     * @param $message
+     * @param  $message
      * @param  array  $additionalParameters
      * @param  \BotMan\BotMan\Messages\Incoming\IncomingMessage  $matchingMessage
      * @return array
@@ -280,7 +282,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
     }
 
     /**
-     * @param $message
+     * @param  $message
      * @param  array  $additionalParameters
      * @param  \BotMan\BotMan\Messages\Incoming\IncomingMessage  $matchingMessage
      * @return array
@@ -428,7 +430,9 @@ class SlackDriver extends HttpDriver implements VerifiesService
     {
         $payload = Collection::make(json_decode($request->getContent(), true));
         if ($payload->get('type') === 'url_verification') {
-            return Response::create($payload->get('challenge'))->send();
+            $response = new Response($payload->get('challenge'));
+
+            return $response->send();
         }
     }
 
@@ -477,7 +481,9 @@ class SlackDriver extends HttpDriver implements VerifiesService
                 if (count($errors)) {
                     $this->bot->touchCurrentConversation();
 
-                    return Response::create(json_encode(['errors' => $errors]), 200, ['ContentType' => 'application/json'])->send();
+                    $responseObj = new Response(json_encode(['errors' => $errors]), 200, ['ContentType' => 'application/json']);
+
+                    return $responseObj->send();
                 } else {
                     if ($next instanceof \Closure) {
                         $next = $next->bindTo($this, $this);

--- a/src/SlackRTMDriver.php
+++ b/src/SlackRTMDriver.php
@@ -250,6 +250,12 @@ class SlackRTMDriver implements DriverInterface
      */
     public function buildServicePayload($message, $matchingMessage, $additionalParameters = [])
     {
+        // If the matching message is in a thread, reply there
+        $thread_ts = $matchingMessage->getPayload()->get('thread_ts');
+        if (! empty($thread_ts)) {
+            $additionalParameters['thread_ts'] = $thread_ts;
+        }
+
         $parameters = array_replace_recursive([
             'channel' => $matchingMessage->getRecipient() ?: $matchingMessage->getSender(),
             'as_user' => true,
@@ -308,9 +314,7 @@ class SlackRTMDriver implements DriverInterface
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage)
     {
-        $additionalParameters['thread_ts'] = ! empty($matchingMessage->getPayload()->get('thread_ts'))
-            ? $matchingMessage->getPayload()->get('thread_ts')
-            : $matchingMessage->getPayload()->get('ts');
+        $additionalParameters['thread_ts'] = $matchingMessage->getPayload()->get('ts');
 
         return $this->reply($message, $matchingMessage, $additionalParameters);
     }


### PR DESCRIPTION
Using the Slack driver with a newer Laravel stack (not sure what the cutoff is exactly) causes URL verification responses, notably, to not be sent due to the removal of the `create()` function in favor of a regular constructor. I've tested that this change solves that issue.

Also applies https://github.styleci.io/analyses/g6odEd.