### PR TITLE
Always reply in existing threads

### DIFF
--- a/src/SlackDriver.php
+++ b/src/SlackDriver.php
@@ -236,7 +236,15 @@ class SlackDriver extends HttpDriver implements VerifiesService
      */
     public function buildServicePayload($message, $matchingMessage, $additionalParameters = [])
     {
-        if (! Collection::make($matchingMessage->getPayload())->has('team_domain')) {
+        $matchingMessagePayload = $matchingMessage->getPayload();
+
+        // If the matching message is in a thread, reply there
+        $thread_ts = $matchingMessagePayload->get('thread_ts');
+        if (! empty($thread_ts)) {
+            $additionalParameters['thread_ts'] = $thread_ts;
+        }
+
+        if (! Collection::make($matchingMessagePayload)->has('team_domain')) {
             $this->resultType = self::RESULT_TOKEN;
             $payload = $this->replyWithToken($message, $matchingMessage, $additionalParameters);
         } else {
@@ -263,16 +271,14 @@ class SlackDriver extends HttpDriver implements VerifiesService
     }
 
     /**
-     * @param $message
+     * @param  $message
      * @param  array  $additionalParameters
      * @param  \BotMan\BotMan\Messages\Incoming\IncomingMessage  $matchingMessage
      * @return array
      */
     public function replyInThread($message, $additionalParameters, $matchingMessage, BotMan $bot)
     {
-        $additionalParameters['thread_ts'] = ! empty($matchingMessage->getPayload()->get('thread_ts'))
-            ? $matchingMessage->getPayload()->get('thread_ts')
-            : $matchingMessage->getPayload()->get('ts');
+        $additionalParameters['thread_ts'] = $matchingMessage->getPayload()->get('ts');
 
         $payload = $this->buildServicePayload($message, $matchingMessage, $additionalParameters);
 
@@ -280,7 +286,7 @@ class SlackDriver extends HttpDriver implements VerifiesService
     }
 
     /**
-     * @param $message
+     * @param  $message
      * @param  array  $additionalParameters
      * @param  \BotMan\BotMan\Messages\Incoming\IncomingMessage  $matchingMessage
      * @return array


### PR DESCRIPTION
In my opinion there is no reason for the bot to be replying to a message sent in a thread directly in the channel. `replyInThread()` is not adequate because it always creates a new thread if there isn't one already (plus it is annoying to use in conjunction with other drivers that don't have that function).

Keeping things simple, set the thread when building the payload for the reply. If using `replyInThread()`. This also reverts https://github.com/botman/botman/pull/328 since the thread ID will be overridden in `buildServicePayload()` if it already exists anyway.

Applying unrelated StyleCI diff in the same commit.